### PR TITLE
Mousewheel test

### DIFF
--- a/Desktop.Robot.TestApp/MouseTests.fs
+++ b/Desktop.Robot.TestApp/MouseTests.fs
@@ -110,6 +110,21 @@ let tests (window:Window) = testList "Mouse tests" [
     testMouseDownUp RightButton
     testMouseDownUp MiddleButton
 
+    uiTest "Can scroll vertical" <| async {
+        let wheelDeltas = window.PointerWheelChanged.Select(fun x -> x.Delta)
+
+        let! deltaEvents = attemptUIActionList wheelDeltas <| async {
+            Robot().MouseScrollVertical(100) // scroll down
+            Robot().MouseScrollVertical(-100) // then scroll up
+        }
+        Expect.hasLength deltaEvents 2 "Should have a wheel event for each mouse scroll"
+        let xDeltas = deltaEvents |> List.map (fun p -> p.X)
+        let yDeltas = deltaEvents |> List.map (fun p -> p.Y)
+        Expect.allEqual xDeltas 0 "Should not scroll horizontally"
+        Expect.isLessThan yDeltas[0] 0 "Should scroll down first"
+        Expect.isGreaterThan yDeltas[1] 0 "Should scroll up next"
+    }
+
     uiTest "Can move to point" <| async {
         let toPixelPoint (p:Point) = PixelPoint(int p.X, int p.Y)
         let toDrawingPoint (p:PixelPoint) = Drawing.Point(p.X, p.Y)

--- a/Desktop.Robot.TestApp/Program.fs
+++ b/Desktop.Robot.TestApp/Program.fs
@@ -58,6 +58,8 @@ type MainWindow() as this =
             .Subscribe(fun _ -> runTests())
             |> ignore
 
+        this.PointerWheelChanged.ObserveOn(SynchronizationContext.Current).Subscribe(fun x -> printfn "Wheel %f ... %A" x.Delta.Y x) |> ignore
+
 type App() =
     inherit Application()
 

--- a/Desktop.Robot/Linux/Robot.cs
+++ b/Desktop.Robot/Linux/Robot.cs
@@ -74,7 +74,7 @@ namespace Desktop.Robot.Linux
             if (value < 0)
             {
                 click(true, Common.UP_BUTTON);
-                Thread.Sleep(value);
+                Thread.Sleep(-value);
                 click(false, Common.UP_BUTTON);
             }
             else


### PR DESCRIPTION
Adds a test for the new mousewheel method from #38.

It helped find a bug on Linux.
Haven't tested on Mac.

On Windows I get this error:

```
[21:51:54 INF] EXPECTO? Running tests... <Expecto>
[21:51:54 ERR] Desktop.Robot test app.Mouse tests.Can scroll vertical errored in 00:00:00.0200000 <Expecto>
System.ArgumentException: Type 'Desktop.Robot.Windows.Robot+Input[]' cannot be marshaled as an unmanaged structure; no meaningful size or offset can be computed.
   at System.Runtime.InteropServices.Marshal.SizeOfHelper(Type t, Boolean throwIfNotMarshalable)
   at System.Runtime.InteropServices.Marshal.SizeOf[T](T structure)
   at Desktop.Robot.Windows.Robot.MouseScrollVertical(Int32 value) in C:\Users\Oliver\Downloads\Desktop.Robot-mousewheel-test (1)\Desktop.Robot-mousewheel-test\Desktop.Robot\Windows\Robot.cs:line 182
   at Desktop.Robot.Robot.MouseScrollVertical(Int32 value) in C:\Users\Oliver\Downloads\Desktop.Robot-mousewheel-test (1)\Desktop.Robot-mousewheel-test\Desktop.Robot\Robot.cs:line 107
   at MouseTests.tests@117-33.Invoke(Unit unitVar) in C:\Users\Oliver\Downloads\Desktop.Robot-mousewheel-test (1)\Desktop.Robot-mousewheel-test\Desktop.Robot.TestApp\MouseTests.fs:line 117
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 508
   at UITestingUtils.robotDoOnThreadpool@81-6.Invoke(AsyncActivation`1 ctxt)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112
[21:51:57 INF] EXPECTO! 49 tests run in 00:00:03.1372604 for Desktop.Robot test app - 48 passed, 93 ignored, 0 failed, 1 errored.  <Expecto>
```