### PR TITLE
Fix quotation marks and brackets on Windows

### DIFF
--- a/Desktop.Robot.TestApp/KeyboardTests.fs
+++ b/Desktop.Robot.TestApp/KeyboardTests.fs
@@ -177,6 +177,12 @@ let tests (window:Window) = testList "Keybard tests" [
             do! testBody tb
         }
 
+    let textboxTest name expectedMessage robotAction = keyboardTest name <| fun tb -> async {
+        do! robotDoOnThreadpool <| async { do robotAction (Robot()) }
+        do! pressKeyAndWaitForEvent tb Key.Esc
+        Expect.equal tb.Text expectedMessage "Should get expected key"
+    }
+
     keyboardTest "Simple keypess" <| fun tb -> async {
         do! pressKeyAndWaitForEvent tb Key.A
         Expect.equal tb.Text "a" "Should press A"
@@ -205,7 +211,12 @@ let tests (window:Window) = testList "Keybard tests" [
 
         testList "Alphabet keys" (List.map regularKeyTest alphabetKeys)
         testList "Digit keys" (List.map regularKeyTest digitKeys)
-        // Dodo: Test more testable sets of keycodes
+
+        testList "Some misc keys" [
+            textboxTest "Single quotation mark" "'" (fun rb -> rb.KeyPress(Key.QuotationMark))
+            textboxTest "Double quotation mark with shift" "\"" (fun rb -> ignore <| rb.CombineKeys(Key.Shift, Key.QuotationMark))
+        ]
+        // Todo: Test more testable sets of keycodes
 
         // don't test all keycodes, a bunch are broken anyway and many have different
         // behavious (eg. PrintScreen, NumLock, Modifiers etc.)

--- a/Desktop.Robot.TestApp/KeyboardTests.fs
+++ b/Desktop.Robot.TestApp/KeyboardTests.fs
@@ -215,6 +215,9 @@ let tests (window:Window) = testList "Keybard tests" [
         testList "Some misc keys" [
             textboxTest "Single quotation mark" "'" (fun rb -> rb.KeyPress(Key.QuotationMark))
             textboxTest "Double quotation mark with shift" "\"" (fun rb -> ignore <| rb.CombineKeys(Key.Shift, Key.QuotationMark))
+            textboxTest "Brackets" "[]" (fun rb -> ignore <| rb.KeyPress(Key.OpenBracket); rb.KeyPress(Key.CloseBracket))
+            textboxTest "Forward slash" "/" (fun rb -> rb.KeyPress(Key.Slash))
+            textboxTest "Question mark" "?"(fun rb -> ignore <| rb.CombineKeys(Key.Shift, Key.Slash))
         ]
         // Todo: Test more testable sets of keycodes
 

--- a/Desktop.Robot.TestApp/MouseTests.fs
+++ b/Desktop.Robot.TestApp/MouseTests.fs
@@ -115,8 +115,8 @@ let tests (window:Window) = testList "Mouse tests" [
         let robot = Robot();
         robot.AutoDelay <- 100;
         let! deltaEvents = attemptUIActionList wheelDeltas <| async {
-            robot.MouseScroll(100) // scroll down
-            robot.MouseScroll(-100) // then scroll up
+            robot.MouseScroll(1) // scroll down
+            robot.MouseScroll(-1) // then scroll up
         }
         Expect.hasLength deltaEvents 2 "Should have a wheel event for each mouse scroll"
         let xDeltas = deltaEvents |> List.map (fun p -> p.X)

--- a/Desktop.Robot.TestApp/Program.fs
+++ b/Desktop.Robot.TestApp/Program.fs
@@ -16,11 +16,11 @@ type MainWindow() as this =
         this.Title <- "Desktop.Robot test app"
         this.Width <- 300.
         this.Height <- 200.
-        
+
         let btn = Button()
         this.Content <- btn
         btn.Content <- "Click to start test"
-        btn.Width <- 100.
+        btn.Width <- 150.
         btn.Height <- 50.
         let runTests () =
             this.Content <- null

--- a/Desktop.Robot/Key.cs
+++ b/Desktop.Robot/Key.cs
@@ -225,7 +225,7 @@ namespace Desktop.Robot
         Dollar,
 
         [Keycode(Platform = "OSX", Keycode = 0x2C)]
-        [Keycode(Platform = "Windows", Keycode = 0x5A)]
+        [Keycode(Platform = "Windows", Keycode = 0xBF)]
         [Keycode(Platform = "Linux", Keycode = 0x002f)]
         Slash,
 

--- a/Desktop.Robot/Key.cs
+++ b/Desktop.Robot/Key.cs
@@ -255,7 +255,7 @@ namespace Desktop.Robot
         GreaterThan,
 
         [Keycode(Platform = "OSX", Keycode = 0x27)]
-        [Keycode(Platform = "Windows", Keycode = 0x5A)]
+        [Keycode(Platform = "Windows", Keycode = 0xDE)]
         [Keycode(Platform = "Linux", Keycode = 0x0022)]
         QuotationMark,
 
@@ -270,12 +270,12 @@ namespace Desktop.Robot
         CloseParenthesis,
 
         [Keycode(Platform = "OSX", Keycode = 0x21)]
-        [Keycode(Platform = "Windows", Keycode = 0x5A)]
+        [Keycode(Platform = "Windows", Keycode = 0xDB)]
         [Keycode(Platform = "Linux", Keycode = 0x005b)]
         OpenBracket,
 
         [Keycode(Platform = "OSX", Keycode = 0x1E)]
-        [Keycode(Platform = "Windows", Keycode = 0x5A)]
+        [Keycode(Platform = "Windows", Keycode = 0xDD)]
         [Keycode(Platform = "Linux", Keycode = 0x005d)]
         CloseBracket,
 


### PR DESCRIPTION
Also adds test for quotation marks. The test fails on linux because it uses `CombineKeys`.

Fixes #55